### PR TITLE
changed AWS provider syntax

### DIFF
--- a/test/.terraform.lock.hcl
+++ b/test/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.60.0"
+  constraints = ">= 3.71.0"
+  hashes = [
+    "h1:dtAnw6tXxtBV4DaASHz1yEONtDn2XptsNJmdzv/X1Gg=",
+    "zh:1853d6bc89e289ac36c13485e8ff877c1be8485e22f545bb32c7a30f1d1856e8",
+    "zh:4321d145969e3b7ede62fe51bee248a15fe398643f21df9541eef85526bf3641",
+    "zh:4c01189cc6963abfe724e6b289a7c06d2de9c395011d8d54efa8fe1aac444e2e",
+    "zh:5934db7baa2eec0f9acb9c7f1c3dd3b3fe1e67e23dd4a49e9fe327832967b32b",
+    "zh:5fbedf5d55c6e04e34c32b744151e514a80308e7dec633a56b852829b41e4b5a",
+    "zh:651558e1446cc05061b75e6f5cc6e2959feb17615cd0ace6ec7a2bcc846321c0",
+    "zh:76875eb697916475e554af080f9d4d3cd1f7d5d58ecdd3317a844a30980f4eec",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a52528e6d6c945a6ac45b89e9a70a5435148e4c151241e04c231dd2acc4a8c80",
+    "zh:af5f94c69025f1c2466a3cf970d1e9bed72938ec33b976c8c067468b6707bb57",
+    "zh:b6692fad956c9d4ef4266519d9ac2ee9f699f8f2c21627625c9ed63814d41590",
+    "zh:b74311af5fa5ac6e4eb159c12cfb380dfe2f5cd8685da2eac8073475f398ae60",
+    "zh:cc5aa6f738baa42edacba5ef1ca0969e5a959422e4491607255f3f6142ba90ed",
+    "zh:dd1a7ff1b22f0036a76bc905a8229ce7ed0a7eb5a783d3a2586fb1bd920515c3",
+    "zh:e5ab40c4ad0f1c7bd4d5d834d1aa144e690d1a93329d73b3d37512715a638de9",
+  ]
+}

--- a/test/versions.tf
+++ b/test/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.71.0"
+      version = ">= 3.71.0"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.71.0"
+      version = ">= 3.71.0"
       configuration_aliases = [
         aws.cluster,
         aws.parent,


### PR DESCRIPTION
[#927](https://github.com/ministryofjustice/analytics-platform-infrastructure/issues/927)

## What has changed?

Changed AWS provider syntax

## Why is this needed?

Fixes a constraint issue in the when upgrading the AWS provider in the analytical-platform-infrastructure repo
Terraform validates ok.
Terraform plan fails:

│ Error: no matching Route53Zone found
│ 
│   with module.example.data.aws_route53_zone.parent,
│   on ../main.tf line 18, in data "aws_route53_zone" "parent":
│   18: data "aws_route53_zone" "parent" {

To test and confirm it works - change the reference to this module in the analytical-platform-infrastructure repo from a version to this branch name - https://github.com/ministryofjustice/ap-terraform-eks-dns/tree/fix-AWS-constraint

## What should the reviewer concentrate on?

Change is valid.
